### PR TITLE
Add support for retrieving all IdentityFile directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ want to retrieve.
 port := ssh_config.Get("myhost", "Port")
 ```
 
+Certain directives can occur multiple times for a host (such as `IdentityFile`),
+so you should use the `GetAll` or `GetAllStrict` directive to retrieve those
+instead.
+
+```go
+files := ssh_config.GetAll("myhost", "IdentityFile")
+```
+
 You can also load a config file and read values from it.
 
 ```go

--- a/config.go
+++ b/config.go
@@ -226,25 +226,7 @@ func (u *UserSettings) GetAllStrict(alias, key string) ([]string, error) {
 	if err2 != nil || val2 != nil {
 		return val2, err2
 	}
-
-	if strings.ToLower(key) == "identityfile" {
-		switch u.Get(alias, "Protocol") {
-		case "1":
-			return []string{defaults["identityfile"]}, nil
-		case "2":
-			def := make([]string, len(defaultProtocol2Identities))
-			copy(def, defaultProtocol2Identities)
-			return def, nil
-		}
-	}
-
-	// return any single defaults if they exist
-	def := Default(key)
-	if def != "" {
-		return []string{def}, nil
-	}
-
-	return nil, nil
+	return DefaultAll(key, alias, u.Get), nil
 }
 
 func (u *UserSettings) doLoadConfigs() {

--- a/config.go
+++ b/config.go
@@ -102,6 +102,13 @@ func findVal(c *Config, alias, key string) (string, error) {
 	return val, nil
 }
 
+func findAll(c *Config, alias, key string) ([]string, error) {
+	if c == nil {
+		return nil, nil
+	}
+	return c.GetAll(alias, key)
+}
+
 // Get finds the first value for key within a declaration that matches the
 // alias. Get returns the empty string if no value was found, or if IgnoreErrors
 // is false and we could not parse the configuration file. Use GetStrict to
@@ -112,6 +119,18 @@ func findVal(c *Config, alias, key string) (string, error) {
 // Get is a wrapper around DefaultUserSettings.Get.
 func Get(alias, key string) string {
 	return DefaultUserSettings.Get(alias, key)
+}
+
+// GetAll retrieves zero or more directives for key for the given alias. GetAll
+// returns nil if no value was found, or if IgnoreErrors is false and we could
+// not parse the configuration file. Use GetAllStrict to disambiguate the
+// latter cases.
+//
+// The match for key is case insensitive.
+//
+// GetAll is a wrapper around DefaultUserSettings.GetAll.
+func GetAll(alias, key string) []string {
+	return DefaultUserSettings.GetAll(alias, key)
 }
 
 // GetStrict finds the first value for key within a declaration that matches the
@@ -125,6 +144,16 @@ func Get(alias, key string) string {
 // GetStrict is a wrapper around DefaultUserSettings.GetStrict.
 func GetStrict(alias, key string) (string, error) {
 	return DefaultUserSettings.GetStrict(alias, key)
+}
+
+// GetAllStrict retrieves zero or more directives for key for the given alias.
+//
+// error will be non-nil if and only if a user's configuration file or the
+// system configuration file could not be parsed, and u.IgnoreErrors is false.
+//
+// GetAllStrict is a wrapper around DefaultUserSettings.GetAllStrict.
+func GetAllStrict(alias, key string) ([]string, error) {
+	return DefaultUserSettings.GetAllStrict(alias, key)
 }
 
 // Get finds the first value for key within a declaration that matches the
@@ -141,6 +170,17 @@ func (u *UserSettings) Get(alias, key string) string {
 	return val
 }
 
+// GetAll retrieves zero or more directives for key for the given alias. GetAll
+// returns nil if no value was found, or if IgnoreErrors is false and we could
+// not parse the configuration file. Use GetStrict to disambiguate the latter
+// cases.
+//
+// The match for key is case insensitive.
+func (u *UserSettings) GetAll(alias, key string) []string {
+	val, _ := u.GetAllStrict(alias, key)
+	return val
+}
+
 // GetStrict finds the first value for key within a declaration that matches the
 // alias. If key has a default value and no matching configuration is found, the
 // default will be returned. For more information on default values and the way
@@ -149,6 +189,65 @@ func (u *UserSettings) Get(alias, key string) string {
 // error will be non-nil if and only if a user's configuration file or the
 // system configuration file could not be parsed, and u.IgnoreErrors is false.
 func (u *UserSettings) GetStrict(alias, key string) (string, error) {
+	u.doLoadConfigs()
+	//lint:ignore S1002 I prefer it this way
+	if u.onceErr != nil && u.IgnoreErrors == false {
+		return "", u.onceErr
+	}
+	val, err := findVal(u.userConfig, alias, key)
+	if err != nil || val != "" {
+		return val, err
+	}
+	val2, err2 := findVal(u.systemConfig, alias, key)
+	if err2 != nil || val2 != "" {
+		return val2, err2
+	}
+	return Default(key), nil
+}
+
+// GetAllStrict retrieves zero or more directives for key for the given alias.
+// If key has a default value and no matching configuration is found, the
+// default will be returned. For more information on default values and the way
+// patterns are matched, see the manpage for ssh_config.
+//
+// error will be non-nil if and only if a user's configuration file or the
+// system configuration file could not be parsed, and u.IgnoreErrors is false.
+func (u *UserSettings) GetAllStrict(alias, key string) ([]string, error) {
+	u.doLoadConfigs()
+	//lint:ignore S1002 I prefer it this way
+	if u.onceErr != nil && u.IgnoreErrors == false {
+		return nil, u.onceErr
+	}
+	val, err := findAll(u.userConfig, alias, key)
+	if err != nil || val != nil {
+		return val, err
+	}
+	val2, err2 := findAll(u.systemConfig, alias, key)
+	if err2 != nil || val2 != nil {
+		return val2, err2
+	}
+
+	if strings.ToLower(key) == "identityfile" {
+		switch u.Get(alias, "Protocol") {
+		case "1":
+			return []string{defaults["identityfile"]}, nil
+		case "2":
+			def := make([]string, len(defaultProtocol2Identities))
+			copy(def, defaultProtocol2Identities)
+			return def, nil
+		}
+	}
+
+	// return any single defaults if they exist
+	def := Default(key)
+	if def != "" {
+		return []string{def}, nil
+	}
+
+	return nil, nil
+}
+
+func (u *UserSettings) doLoadConfigs() {
 	u.loadConfigs.Do(func() {
 		// can't parse user file, that's ok.
 		var filename string
@@ -176,19 +275,6 @@ func (u *UserSettings) GetStrict(alias, key string) (string, error) {
 			return
 		}
 	})
-	//lint:ignore S1002 I prefer it this way
-	if u.onceErr != nil && u.IgnoreErrors == false {
-		return "", u.onceErr
-	}
-	val, err := findVal(u.userConfig, alias, key)
-	if err != nil || val != "" {
-		return val, err
-	}
-	val2, err2 := findVal(u.systemConfig, alias, key)
-	if err2 != nil || val2 != "" {
-		return val2, err2
-	}
-	return Default(key), nil
 }
 
 func parseFile(filename string) (*Config, error) {
@@ -280,6 +366,42 @@ func (c *Config) Get(alias, key string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+// GetAll returns all values in the configuration that match the alias and
+// contains key, or nil if none are present.
+func (c *Config) GetAll(alias, key string) ([]string, error) {
+	lowerKey := strings.ToLower(key)
+	all := []string(nil)
+	for _, host := range c.Hosts {
+		if !host.Matches(alias) {
+			continue
+		}
+		for _, node := range host.Nodes {
+			switch t := node.(type) {
+			case *Empty:
+				continue
+			case *KV:
+				// "keys are case insensitive" per the spec
+				lkey := strings.ToLower(t.Key)
+				if lkey == "match" {
+					panic("can't handle Match directives")
+				}
+				if lkey == lowerKey {
+					all = append(all, t.Value)
+				}
+			case *Include:
+				val, _ := t.GetAll(alias, key)
+				if val != nil {
+					all = append(all, val...)
+				}
+			default:
+				return nil, fmt.Errorf("unknown Node type %v", t)
+			}
+		}
+	}
+
+	return all, nil
 }
 
 // String returns a string representation of the Config file.
@@ -609,6 +731,30 @@ func (inc *Include) Get(alias, key string) string {
 		}
 	}
 	return ""
+}
+
+// GetAll finds all values in the Include statement matching the alias and the
+// given key.
+func (inc *Include) GetAll(alias, key string) ([]string, error) {
+	inc.mu.Lock()
+	defer inc.mu.Unlock()
+	var vals []string
+
+	// TODO: we search files in any order which is not correct
+	for i := range inc.matches {
+		cfg := inc.files[inc.matches[i]]
+		if cfg == nil {
+			panic("nil cfg")
+		}
+		val, err := cfg.GetAll(alias, key)
+		if err == nil && len(val) != 0 {
+			if !IsMultifileDirective(key) {
+				return val, nil
+			}
+			vals = append(vals, val...)
+		}
+	}
+	return vals, nil
 }
 
 // String prints out a string representation of this Include directive. Note

--- a/config_test.go
+++ b/config_test.go
@@ -67,6 +67,64 @@ func TestGetWithDefault(t *testing.T) {
 	}
 }
 
+func TestGetAllWithDefault(t *testing.T) {
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/config1"),
+	}
+
+	val, err := us.GetAllStrict("wap", "PasswordAuthentication")
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if len(val) != 1 || val[0] != "yes" {
+		t.Errorf("expected to get PasswordAuthentication yes, got %q", val)
+	}
+}
+
+func TestGetIdentities(t *testing.T) {
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/identities"),
+	}
+
+	val, err := us.GetAllStrict("hasidentity", "IdentityFile")
+	if err != nil {
+		t.Errorf("expected nil err, got %v", err)
+	}
+	if len(val) != 1 || val[0] != "file1" {
+		t.Errorf(`expected ["file1"], got %v`, val)
+	}
+
+	val, err = us.GetAllStrict("has2identity", "IdentityFile")
+	if err != nil {
+		t.Errorf("expected nil err, got %v", err)
+	}
+	if len(val) != 2 || val[0] != "f1" || val[1] != "f2" {
+		t.Errorf(`expected [\"f1\", \"f2\"], got %v`, val)
+	}
+
+	val, err = us.GetAllStrict("randomhost", "IdentityFile")
+	if err != nil {
+		t.Errorf("expected nil err, got %v", err)
+	}
+	if len(val) != len(defaultProtocol2Identities) {
+		t.Errorf("expected defaults, got %v", val)
+	} else {
+		for i, v := range defaultProtocol2Identities {
+			if val[i] != v {
+				t.Errorf("invalid %d in val, expected %s got %s", i, v, val[i])
+			}
+		}
+	}
+
+	val, err = us.GetAllStrict("protocol1", "IdentityFile")
+	if err != nil {
+		t.Errorf("expected nil err, got %v", err)
+	}
+	if len(val) != 1 || val[0] != "~/.ssh/identity" {
+		t.Errorf("expected [\"~/.ssh/identity\"], got %v", val)
+	}
+}
+
 func TestGetInvalidPort(t *testing.T) {
 	us := &UserSettings{
 		userConfigFinder: testConfigFinder("testdata/invalid-port"),
@@ -94,6 +152,20 @@ func TestGetNotFoundNoDefault(t *testing.T) {
 		t.Fatalf("expected nil err, got %v", err)
 	}
 	if val != "" {
+		t.Errorf("expected to get CanonicalDomains '', got %q", val)
+	}
+}
+
+func TestGetAllNotFoundNoDefault(t *testing.T) {
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/config1"),
+	}
+
+	val, err := us.GetAllStrict("wap", "CanonicalDomains")
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if len(val) != 0 {
 		t.Errorf("expected to get CanonicalDomains '', got %q", val)
 	}
 }

--- a/testdata/identities
+++ b/testdata/identities
@@ -1,0 +1,11 @@
+
+Host hasidentity
+  IdentityFile file1
+
+Host has2identity
+  IdentityFile f1
+  IdentityFile f2
+
+Host protocol1
+  Protocol 1
+

--- a/validators.go
+++ b/validators.go
@@ -15,6 +15,26 @@ func Default(keyword string) string {
 	return defaults[strings.ToLower(keyword)]
 }
 
+// DefaultAll returns the default value for the given keyword, but as a slice. If
+// there is no default for the keyword, nil is returned.
+//
+// Some multi-valued settings have different defaults based on other settings, so
+// you must provide the host alias and a function to retrieve a setting
+func DefaultAll(keyword string, alias string, get func(alias, key string) string) []string {
+	if strings.ToLower(keyword) == "identityfile" && get(alias, "Protocol") == "2" {
+		def := make([]string, len(defaultProtocol2Identities))
+		copy(def, defaultProtocol2Identities)
+		return def
+	}
+
+	def := Default(keyword)
+	if def != "" {
+		return []string{def}
+	}
+
+	return nil
+}
+
 // Arguments where the value must be "yes" or "no" and *only* yes or no.
 var yesnos = map[string]bool{
 	strings.ToLower("BatchMode"):                        true,

--- a/validators.go
+++ b/validators.go
@@ -160,3 +160,28 @@ var defaults = map[string]string{
 	strings.ToLower("VisualHostKey"):      "no",
 	strings.ToLower("XAuthLocation"):      "/usr/X11R6/bin/xauth",
 }
+
+// these identities are used for SSH protocol 2
+var defaultProtocol2Identities = []string{
+	"~/.ssh/id_dsa",
+	"~/.ssh/id_ecdsa",
+	"~/.ssh/id_ed25519",
+	"~/.ssh/id_rsa",
+}
+
+// these directives support multiple items that can be collected
+// across multiple files
+var multifileDirectives = map[string]bool{
+	"CertificateFile": true,
+	"IdentityFile":    true,
+	"DynamicForward":  true,
+	"RemoteForward":   true,
+	"SendEnv":         true,
+	"SetEnv":          true,
+}
+
+// IsMultifileDirective indicates a directive that can be found
+// in more than one file
+func IsMultifileDirective(key string) bool {
+	return multifileDirectives[strings.ToLower(key)]
+}


### PR DESCRIPTION
Additionally, this returns the correct defaults for SSH protocol 2

Unfortunately, since this is the only directive that can have multiple values, there's quite a bit of code duplication. However, it seems to work!