### PR TITLE
Ensure the lexer is done before returning from parseSSH.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -169,6 +169,12 @@ func (p *sshParser) parseComment() sshParserStateFn {
 }
 
 func parseSSH(flow chan token, system bool, depth uint8) *Config {
+	// Ensure we consume tokens to completion even if parser exits early
+	defer func() {
+		for range flow {
+		}
+	}()
+
 	result := newConfig()
 	result.position = Position{1, 1}
 	parser := &sshParser{

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,21 @@
+package ssh_config
+
+import (
+	"errors"
+	"testing"
+)
+
+type errReader struct {
+}
+
+func (b *errReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("bad")
+}
+
+func TestIOError(t *testing.T) {
+	buf := &errReader{}
+	defer func() {
+		recover()
+	}()
+	parseSSH(lexSSH(buf), false, 0)
+}


### PR DESCRIPTION
This avoids panics in the lexer like this:

    panic: read /etc/ssh/ssh_config: file already closed

    goroutine 562 [running]:
    [...]/vendor/github.com/kevinburke/ssh_config.(*sshLexer).peek(0xc00065e080, 0xc000000070)
            [...]/vendor/github.com/kevinburke/ssh_config/lexer.go:202 +0x105
    [...]/vendor/github.com/kevinburke/ssh_config.(*sshLexer).lexRvalue(0xc00065e080, 0xc000c1c010)
            [...]/vendor/github.com/kevinburke/ssh_config/lexer.go:87 +0x5a
    [...]/vendor/github.com/kevinburke/ssh_config.(*sshLexer).run(0xc00065e080)
            [...]/vendor/github.com/kevinburke/ssh_config/lexer.go:224 +0x4a
    created by [...]/vendor/github.com/kevinburke/ssh_config.lexSSH
            [...]/vendor/github.com/kevinburke/ssh_config/lexer.go:239 +0xd1