### PR TITLE
AddingPowerSupport_&_ContinousIntegration/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch: 
+   - amd64
+   - ppc64le
 go_import_path: github.com/kevinburke/ssh_config
 
 language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,16 @@ go:
   - 1.11.x
   - 1.12.x
   - master
+jobs:
+ exclude:
+  - arch: amd64
+    go: 1.11.x
+  - arch: amd64
+    go: 1.12.x
+  - arch: ppc64le
+    go: 1.11.x
+  - arch: ppc64le
+    go: 1.12.x
 
 before_script:
     - go get -u ./...


### PR DESCRIPTION
Adding power support.

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/ssh_config