### PR TITLE
Add support for ~ references to home directories in Include

### DIFF
--- a/config.go
+++ b/config.go
@@ -685,6 +685,8 @@ func NewInclude(directives []string, hasEquals bool, pos Position, comment strin
 			path = directives[i]
 		} else if system {
 			path = filepath.Join("/etc/ssh", directives[i])
+		} else if strings.HasPrefix(directives[i], "~/") {
+			path = filepath.Join(homedir(), directives[i][2:])
 		} else {
 			path = filepath.Join(homedir(), ".ssh", directives[i])
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -345,6 +345,32 @@ func TestIncludeString(t *testing.T) {
 	}
 }
 
+var shellIncludeFile = []byte(`
+# This host should not exist, so we can use it for test purposes / it won't
+# interfere with any other configurations.
+Host kevinburke.ssh_config.test.example.com
+    Port 4567
+`)
+
+func TestIncludeShellHomeDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fs write in short mode")
+	}
+	testPath := filepath.Join(homedir(), "kevinburke-ssh-config-shell-include")
+	err := ioutil.WriteFile(testPath, shellIncludeFile, 0644)
+	if err != nil {
+		t.Skipf("couldn't write SSH config file: %v", err.Error())
+	}
+	defer os.Remove(testPath)
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/include-shell"),
+	}
+	val := us.Get("kevinburke.ssh_config.test.example.com", "Port")
+	if val != "4567" {
+		t.Errorf("expected to find Port=4567 in included file, got %q", val)
+	}
+}
+
 var matchTests = []struct {
 	in    []string
 	alias string

--- a/testdata/include-shell
+++ b/testdata/include-shell
@@ -1,0 +1,2 @@
+Host kevinburke.ssh_config.test.example.com
+    Include ~/kevinburke-ssh-config-shell-include


### PR DESCRIPTION
In ssh_config(5) it says:

    each pathname may contain glob(7) wildcards and, for user configu‐
    rations, shell-like ‘~’ references to user home directories.

This adds support for expanding the ~ into the path for the user's home
directory when not parsing a system config.