### PR TITLE
Fix EOL Comments on KV Nodes

### DIFF
--- a/config.go
+++ b/config.go
@@ -588,7 +588,7 @@ func (k *KV) String() string {
 	}
 	line := fmt.Sprintf("%s%s%s%s", strings.Repeat(" ", int(k.leadingSpace)), k.Key, equals, k.Value)
 	if k.Comment != "" {
-		line += " #" + k.Comment
+		line += "#" + k.Comment
 	}
 	return line
 }

--- a/config_test.go
+++ b/config_test.go
@@ -18,7 +18,7 @@ func loadFile(t *testing.T, filename string) []byte {
 	return data
 }
 
-var files = []string{"testdata/config1", "testdata/config2"}
+var files = []string{"testdata/config1", "testdata/config2", "testdata/eol-comments"}
 
 func TestDecode(t *testing.T) {
 	for _, filename := range files {
@@ -29,7 +29,7 @@ func TestDecode(t *testing.T) {
 		}
 		out := cfg.String()
 		if out != string(data) {
-			t.Errorf("out != data: out: %q\ndata: %q", out, string(data))
+			t.Errorf("%s out != data: out: %q\ndata: %q", filename, out, string(data))
 		}
 	}
 }

--- a/testdata/eol-comments
+++ b/testdata/eol-comments
@@ -1,0 +1,5 @@
+Host example
+    HostName example.com    # aligned eol comment 1
+    ForwardX11Timeout 52w   # aligned eol comment 2
+    AddressFamily inet      # aligned eol comment 3    
+    Port 4242 #compact comment


### PR DESCRIPTION
EOL comments on KV nodes are serialized with an additional space:

Example input:
```
Host example
    HostName example.com # comment
```

Current output:
```
Host example
    HostName example.com  # comment
```

In the above output, an extra space is added before comment start. This breaks round-tripping and causes comments to "drift" right as a config is decoded and encoded over and over again.

This PR proposes a test case demonstrating such behavior and a simple fix for it.