### PR TITLE
config: fix EOL whitespace for key/value pairs and Host lines

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,6 +3,7 @@ Dustin Spicuzza <dustin@virtualroadside.com>
 Eugene Terentev <eugene@terentev.net>
 Kevin Burke <kevin@burke.dev>
 Mark Nevill <nev@improbable.io>
+Scott Lessans <slessans@gmail.com>
 Sergey Lukjanov <me@slukjanov.name>
 Wayne Ashley Berry <wayneashleyberry@gmail.com>
 santosh653 <70637961+santosh653@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changes
+
+## Version 1.2
+
+Previously, if a Host declaration or a value had trailing whitespace, that
+whitespace would have been included as part of the value. This led to unexpected
+consequences. For example:
+
+```
+Host example       # A comment
+    HostName example.com      # Another comment
+```
+
+Prior to version 1.2, the value for Host would have been "example " and the
+value for HostName would have been "example.com      ". Both of these are
+unintuitive.
+
+Instead, we strip the trailing whitespace in the configuration, which leads to
+more intuitive behavior.

--- a/config_test.go
+++ b/config_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func loadFile(t *testing.T, filename string) []byte {
+	t.Helper()
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)
@@ -17,7 +18,11 @@ func loadFile(t *testing.T, filename string) []byte {
 	return data
 }
 
-var files = []string{"testdata/config1", "testdata/config2"}
+var files = []string{
+	"testdata/config1",
+	"testdata/config2",
+	"testdata/eol-comments",
+}
 
 func TestDecode(t *testing.T) {
 	for _, filename := range files {
@@ -28,7 +33,7 @@ func TestDecode(t *testing.T) {
 		}
 		out := cfg.String()
 		if out != string(data) {
-			t.Errorf("out != data: out: %q\ndata: %q", out, string(data))
+			t.Errorf("%s out != data: got:\n%s\nwant:\n%s\n", filename, out, string(data))
 		}
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -3,6 +3,7 @@ package ssh_config
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 type sshParser struct {
@@ -122,11 +123,16 @@ func (p *sshParser) parseKV() sshParserStateFn {
 			}
 			patterns = append(patterns, pat)
 		}
+		// val.val at this point could be e.g. "example.com       "
+		hostval := strings.TrimRightFunc(val.val, unicode.IsSpace)
+		spaceBeforeComment := val.val[len(hostval):]
+		val.val = hostval
 		p.config.Hosts = append(p.config.Hosts, &Host{
-			Patterns:   patterns,
-			Nodes:      make([]Node, 0),
-			EOLComment: comment,
-			hasEquals:  hasEquals,
+			Patterns:           patterns,
+			Nodes:              make([]Node, 0),
+			EOLComment:         comment,
+			spaceBeforeComment: spaceBeforeComment,
+			hasEquals:          hasEquals,
 		})
 		return p.parseStart
 	}
@@ -144,13 +150,16 @@ func (p *sshParser) parseKV() sshParserStateFn {
 		lastHost.Nodes = append(lastHost.Nodes, inc)
 		return p.parseStart
 	}
+	shortval := strings.TrimRightFunc(val.val, unicode.IsSpace)
+	spaceAfterValue := val.val[len(shortval):]
 	kv := &KV{
-		Key:          key.val,
-		Value:        val.val,
-		Comment:      comment,
-		hasEquals:    hasEquals,
-		leadingSpace: key.Position.Col - 1,
-		position:     key.Position,
+		Key:             key.val,
+		Value:           shortval,
+		spaceAfterValue: spaceAfterValue,
+		Comment:         comment,
+		hasEquals:       hasEquals,
+		leadingSpace:    key.Position.Col - 1,
+		position:        key.Position,
 	}
 	lastHost.Nodes = append(lastHost.Nodes, kv)
 	return p.parseStart

--- a/testdata/eol-comments
+++ b/testdata/eol-comments
@@ -1,0 +1,7 @@
+Host example      # this comment terminates a Host line
+    HostName example.com    # aligned eol comment 1
+    ForwardX11Timeout 52w   # aligned eol comment 2
+# This comment takes up a whole line
+          # This comment is offset and takes up a whole line
+    AddressFamily inet      # aligned eol comment 3    
+    Port 4242 #compact comment


### PR DESCRIPTION
See the description in the CHANGELOG - we were handling this
incorrectly and attaching whitespace to the end of values where that
didn't make much sense to do.