### PR TITLE
add function HostAliases

### DIFF
--- a/config.go
+++ b/config.go
@@ -443,16 +443,16 @@ func (c *Config) GetAll(alias, key string) ([]string, error) {
 	return all, nil
 }
 
-// HostsAliases returns all hosts aliases in the configuration that match the
-// given pattern, or nil if none are present.
+// HostAliases returns all host aliases in the configuration that match the
+// given pattern.
 // A host alias matches when its first pattern matches and has a KV node that
 // contains key 'Hostname'.
-func (c *Config) HostsAliases(pattern string) ([]string, error) {
+func (c *Config) HostAliases(pattern string) ([]string, error) {
 	p, err := NewPattern(pattern)
 	if err != nil {
 		return nil, err
 	}
-	all := []string(nil)
+	all := make([]string, 0)
 	for _, host := range c.Hosts {
 		alias := host.Patterns[0].String()
 		ok := alias == "*" || p.regex.MatchString(alias)
@@ -466,8 +466,7 @@ func (c *Config) HostsAliases(pattern string) ([]string, error) {
 				continue
 			case *KV:
 				// "keys are case-insensitive" per the spec
-				lkey := strings.ToLower(t.Key)
-				if lkey == "hostname" {
+				if strings.EqualFold("hostname", t.Key) {
 					all = append(all, alias)
 				}
 			case *Include:
@@ -854,7 +853,7 @@ func (inc *Include) HostsAliases(pattern string) ([]string, error) {
 		if cfg == nil {
 			panic("nil cfg")
 		}
-		val, err := cfg.HostsAliases(pattern)
+		val, err := cfg.HostAliases(pattern)
 		if err == nil && len(val) != 0 {
 			vals = append(vals, val...)
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -470,14 +470,12 @@ func TestCustomFinder(t *testing.T) {
 	}
 }
 
-func TestAliases(t *testing.T) {
-	testDir, err := os.MkdirTemp(os.TempDir(), "test-aliases")
+func TestHostAliases(t *testing.T) {
+	testDir, err := os.MkdirTemp(os.TempDir(), "test-host-aliases")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		_ = os.RemoveAll(testDir)
-	}()
+	defer os.RemoveAll(testDir)
 
 	cp := func(name string) string {
 		bf, err := ioutil.ReadFile(filepath.Join("testdata", name))
@@ -513,16 +511,16 @@ func TestAliases(t *testing.T) {
 
 	assertEqual := func(msg string, expected, actual []string) {
 		if len(expected) != len(actual) {
-			t.Fatal(fmt.Sprintf("%s: expected %d, got %d", msg, len(expected), len(actual)))
+			t.Fatalf("%s: expected %d, got %d", msg, len(expected), len(actual))
 		}
 		for i, exp := range expected {
 			if actual[i] != exp {
-				t.Fatal(fmt.Sprintf("%s: at %d, expected %s, got %s", msg, i, exp, actual[i]))
+				t.Fatalf("%s: at %d, expected %s, got %s", msg, i, exp, actual[i])
 			}
 		}
 	}
 
-	prodAliases, err := config.HostsAliases("*.prod.dom")
+	prodAliases, err := config.HostAliases("*.prod.dom")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +529,7 @@ func TestAliases(t *testing.T) {
 		[]string{"ab8-001.prod.dom", "ab8-002.prod.dom", "cd8-003.prod.dom"},
 		prodAliases)
 
-	testAliases, err := config.HostsAliases("*.test.dom")
+	testAliases, err := config.HostAliases("*.test.dom")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -540,7 +538,7 @@ func TestAliases(t *testing.T) {
 		[]string{"ab8-004.test.dom", "fr5-002.test.dom"},
 		testAliases)
 
-	abAliases, err := config.HostsAliases("ab*")
+	abAliases, err := config.HostAliases("ab*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -549,7 +547,7 @@ func TestAliases(t *testing.T) {
 		[]string{"ab8-001.prod.dom", "ab8-002.prod.dom", "ab8-004.test.dom"},
 		abAliases)
 
-	okAliases, err := config.HostsAliases("ok*")
+	okAliases, err := config.HostAliases("ok*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testdata/include_prod
+++ b/testdata/include_prod
@@ -1,0 +1,17 @@
+### Hosts in the production environment
+
+Host *.prod.dom
+  ForwardAgent yes
+  User srv-prod
+  CertificateFile ~/.ssh/keys.d/id_signed_cert_srv-prod
+  IdentityFile ~/.ssh/keys.d/id_key
+  IdentitiesOnly yes
+
+Host ab8-001.prod.dom
+  Hostname 10.1.0.1
+
+Host ab8-002.prod.dom
+  Hostname 10.1.0.2
+
+Host cd8-003.prod.dom
+  Hostname 10.1.0.3

--- a/testdata/include_test
+++ b/testdata/include_test
@@ -1,0 +1,13 @@
+### Hosts in the test environment
+
+Host *.test.dom
+  ForwardAgent yes
+  IdentityFile ~/.ssh/keys.d/id_key
+  IdentitiesOnly yes
+  User srv-test
+
+Host ab8-004.test.dom
+  Hostname 10.1.0.4
+
+Host fr5-002.test.dom
+  Hostname 10.1.0.5


### PR DESCRIPTION
Add func `HostAliases` that returns all host aliases in the configuration that match the given pattern.

The use case is - a command line tool - where configuration are updated more or less without notice and the need is to reach hosts based on their alias. After calling `HostAliases`, one can use the regular API to complete hosts information.