### PR TITLE
config: support `~` as user's home directory for `Include`

### DIFF
--- a/config.go
+++ b/config.go
@@ -732,6 +732,8 @@ func NewInclude(directives []string, hasEquals bool, pos Position, comment strin
 			path = directives[i]
 		} else if system {
 			path = filepath.Join("/etc/ssh", directives[i])
+		} else if strings.HasPrefix(directives[i], "~/") || strings.HasPrefix(directives[i], "~\\") {
+			path = filepath.Join(homedir(), directives[i][2:])
 		} else {
 			path = filepath.Join(homedir(), ".ssh", directives[i])
 		}


### PR DESCRIPTION
e.g., `Include ~/other/config` on Linux, `Include ~\other\config` on Windows.