### PR TITLE
Add a function that can reload config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Some SSH arguments have default values - for example, the default value for
 given Host/keyword pair exists in the config, we'll return a default for the
 keyword if one exists.
 
+### Clearing cached SSH config files
+Once the first call to `Get()`, `GetStrict()`, `GetAll()`, or `GetAllStrict()`
+has been made, the contents of the config files will be cached for all future
+calls to any of those functions. This cache can manually be cleared with the
+`ClearCachedConfigs()` function. Once this is done, it will be cached again by
+the next call to `Get()`, `GetStrict()`, `GetAll()`, or `GetAllStrict()`.
+
+```go
+ssh_config.ClearCachedConfigs()
+```
+
 ### Manipulating SSH config files
 
 Here's how you can manipulate an SSH config file, and then write it back to

--- a/README.md
+++ b/README.md
@@ -42,15 +42,14 @@ Some SSH arguments have default values - for example, the default value for
 given Host/keyword pair exists in the config, we'll return a default for the
 keyword if one exists.
 
-### Clearing cached SSH config files
+### Reloading SSH config files
 Once the first call to `Get()`, `GetStrict()`, `GetAll()`, or `GetAllStrict()`
 has been made, the contents of the config files will be cached for all future
-calls to any of those functions. This cache can manually be cleared with the
-`ClearCachedConfigs()` function. Once this is done, it will be cached again by
-the next call to `Get()`, `GetStrict()`, `GetAll()`, or `GetAllStrict()`.
+calls to any of those functions. The `ReloadConfigs()` function will reset
+this cache and replace it with the current config file contents.
 
 ```go
-ssh_config.ClearCachedConfigs()
+ssh_config.ReloadConfigs()
 ```
 
 ### Manipulating SSH config files

--- a/config.go
+++ b/config.go
@@ -167,13 +167,12 @@ func GetAllStrict(alias, key string) ([]string, error) {
 	return DefaultUserSettings.GetAllStrict(alias, key)
 }
 
-// ClearCachedConfigs resets the loaded config so it can be reloaded on the
-// next retrieval.
+// ReloadConfigs clears the cached config data and freshly loads the config
+// files again.
 //
-// ClearCachedConfigs is a wrapper around
-// DefaultUserSettings.ClearCachedConfigs.
-func ClearCachedConfigs() {
-	DefaultUserSettings.ClearCachedConfigs()
+// ReloadConfigs is a wrapper around DefaultUserSettings.ReloadConfigs.
+func ReloadConfigs() {
+	DefaultUserSettings.ReloadConfigs()
 }
 
 // Get finds the first value for key within a declaration that matches the
@@ -281,6 +280,9 @@ func (u *UserSettings) ConfigFinder(f func() string) {
 }
 
 func (u *UserSettings) doLoadConfigs() {
+	if u.loadConfigs == nil {
+		u.loadConfigs = new(sync.Once)
+	}
 	u.loadConfigs.Do(func() {
 		var filename string
 		var err error
@@ -319,10 +321,11 @@ func (u *UserSettings) doLoadConfigs() {
 	})
 }
 
-// ClearCachedConfigs resets the loaded config so it can be reloaded on the
-// next retrieval.
-func (u *UserSettings) ClearCachedConfigs() {
+// ReloadConfigs clears the cached config data and freshly loads the config
+// files again.
+func (u *UserSettings) ReloadConfigs() {
 	u.loadConfigs = new(sync.Once)
+	u.doLoadConfigs()
 }
 
 func parseFile(filename string) (*Config, error) {

--- a/config.go
+++ b/config.go
@@ -8,7 +8,7 @@
 // the host name to match on ("example.com"), and the second argument is the key
 // you want to retrieve ("Port"). The keywords are case insensitive.
 //
-// 		port := ssh_config.Get("myhost", "Port")
+//	port := ssh_config.Get("myhost", "Port")
 //
 // You can also manipulate an SSH config file and then print it or write it back
 // to disk.
@@ -59,7 +59,7 @@ type UserSettings struct {
 	systemConfigFinder configFinder
 	userConfig         *Config
 	userConfigFinder   configFinder
-	loadConfigs        sync.Once
+	loadConfigs        *sync.Once
 	onceErr            error
 }
 
@@ -165,6 +165,15 @@ func GetStrict(alias, key string) (string, error) {
 // GetAllStrict is a wrapper around DefaultUserSettings.GetAllStrict.
 func GetAllStrict(alias, key string) ([]string, error) {
 	return DefaultUserSettings.GetAllStrict(alias, key)
+}
+
+// ClearCachedConfigs resets the loaded config so it can be reloaded on the
+// next retrieval.
+//
+// ClearCachedConfigs is a wrapper around
+// DefaultUserSettings.ClearCachedConfigs.
+func ClearCachedConfigs() {
+	DefaultUserSettings.ClearCachedConfigs()
 }
 
 // Get finds the first value for key within a declaration that matches the
@@ -308,6 +317,12 @@ func (u *UserSettings) doLoadConfigs() {
 			return
 		}
 	})
+}
+
+// ClearCachedConfigs resets the loaded config so it can be reloaded on the
+// next retrieval.
+func (u *UserSettings) ClearCachedConfigs() {
+	u.loadConfigs = new(sync.Once)
 }
 
 func parseFile(filename string) (*Config, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -259,6 +259,72 @@ func TestGetEqsign(t *testing.T) {
 	}
 }
 
+var modified1 = []byte(`
+Host wap
+  User modified1
+  KexAlgorithms diffie-hellman-group1-sha1
+`)
+
+var modified2 = []byte(`
+Host wap
+  User modified2
+  KexAlgorithms diffie-hellman-group1-sha1
+`)
+
+func TestCachedConfig(t *testing.T) {
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/modified"),
+	}
+
+	err1 := os.WriteFile("testdata/modified", modified1, 0644)
+	if err1 != nil {
+		t.Errorf("error writing to file: %v", err1)
+	}
+
+	val1 := us.Get("wap", "User")
+	if val1 != "modified1" {
+		t.Errorf("expected to find User modified1, got %q", val1)
+	}
+
+	err2 := os.WriteFile("testdata/modified", modified2, 0644)
+	if err1 != nil {
+		t.Errorf("error writing to file: %v", err2)
+	}
+
+	val2 := us.Get("wap", "User")
+	if val2 != "modified1" {
+		t.Errorf("expected to find User modified1, got %q", val2)
+	}
+}
+
+func TestReloadConfigs(t *testing.T) {
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/modified"),
+	}
+
+	err1 := os.WriteFile("testdata/modified", modified1, 0644)
+	if err1 != nil {
+		t.Errorf("error writing to file: %v", err1)
+	}
+
+	val1 := us.Get("wap", "User")
+	if val1 != "modified1" {
+		t.Errorf("expected to find User modified1, got %q", val1)
+	}
+
+	err2 := os.WriteFile("testdata/modified", modified2, 0644)
+	if err1 != nil {
+		t.Errorf("error writing to file: %v", err2)
+	}
+
+	us.ReloadConfigs()
+
+	val2 := us.Get("wap", "User")
+	if val2 != "modified2" {
+		t.Errorf("expected to find User modified2, got %q", val2)
+	}
+}
+
 var includeFile = []byte(`
 # This host should not exist, so we can use it for test purposes / it won't
 # interfere with any other configurations.

--- a/testdata/modified
+++ b/testdata/modified
@@ -1,0 +1,4 @@
+
+Host wap
+  User modified2
+  KexAlgorithms diffie-hellman-group1-sha1


### PR DESCRIPTION
This change addresses issue #63. To summarize, this change adds a function `ReloadConfigs()` that will reload the data from ssh config files in case they were modified externally.

This involves changing the type of UserSettings.loadConfigs from sync.Once to a pointer *sync.Once. This makes it possible to swap out one pointer for another if requested by the `ReloadConfigs()` function.

In addition, this change updates the README.md file with additional documentation explaining what the function is. It also adds two tests that demonstrate the difference between when `ReloadConfigs()` is used and when it isn't.