### PR TITLE
Add support for Match (Fixes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ Wherever possible we try to implement the specification as documented in
 the `ssh_config` manpage. Unimplemented features should be present in the
 [issues][issues] list.
 
-Notably, the `Match` directive is currently unsupported.
-
 [issues]: https://github.com/kevinburke/ssh_config/issues
 
 ## Errata

--- a/config.go
+++ b/config.go
@@ -24,9 +24,6 @@
 //
 //	// Write the cfg back to disk:
 //	fmt.Println(cfg.String())
-//
-// BUG: the Match directive is currently unsupported; parsing a config with
-// a Match directive will trigger an error.
 package ssh_config
 
 import (
@@ -538,6 +535,8 @@ type Host struct {
 	EOLComment string
 	// Whitespace if any between the Host declaration and a trailing comment.
 	spaceBeforeComment string
+	// Whether this Host block was created by a Match directive
+	isMatch bool
 
 	hasEquals    bool
 	leadingSpace int // TODO: handle spaces vs tabs here.

--- a/config_test.go
+++ b/config_test.go
@@ -388,7 +388,7 @@ func TestMatches(t *testing.T) {
 	}
 }
 
-func TestMatchUnsupported(t *testing.T) {
+func TestMatchSupported(t *testing.T) {
 	us := &UserSettings{
 		userConfigFinder: testConfigFinder("testdata/match-directive"),
 	}
@@ -397,7 +397,7 @@ func TestMatchUnsupported(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected Match directive to error, didn't")
 	}
-	if !strings.Contains(err.Error(), "ssh_config: Match directive parsing is unsupported") {
+	if strings.Contains(err.Error(), "ssh_config: Match directive parsing is now supported") {
 		t.Errorf("wrong error: %v", err)
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,6 +2,7 @@ package ssh_config
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -20,5 +21,327 @@ func TestIOError(t *testing.T) {
 	}
 	if err.Error() != "read error occurred" {
 		t.Errorf("expected read error msg, got %v", err)
+	}
+}
+
+func TestParseMatchHostString(t *testing.T) {
+	var config = `
+Match Host *.example.com
+  Compression yes
+  HostName test.example.com
+  Port 2222
+  User hi_there
+`
+
+	cfg, err := Decode(strings.NewReader(config))
+	if err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	val, err := cfg.Get("dev.example.com", "Port")
+	if err != nil {
+		t.Errorf("failed to get Port: %v", err)
+	}
+	if val != "2222" {
+		t.Errorf("expected Port=2222, got %q", val)
+	}
+
+	val, err = cfg.Get("uat.example.com", "User")
+	if err != nil {
+		t.Errorf("failed to get User: %v", err)
+	}
+	if val != "hi_there" {
+		t.Errorf("expected User=hi_there, got %q", val)
+	}
+
+	val, err = cfg.Get("prod.example.com", "HostName")
+	if err != nil {
+		t.Errorf("failed to get User: %v", err)
+	}
+	if val != "test.example.com" {
+		t.Errorf("expected HostName=test.example.com, got %q", val)
+	}
+}
+
+func TestMatchDirective(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		alias    string
+		key      string
+		wantVal  string
+		wantErr  bool
+		errMatch string
+	}{
+		{
+			name: "basic match host",
+			config: `Match Host *.example.com
+    Port 2222`,
+			alias:   "test.example.com",
+			key:     "Port",
+			wantVal: "2222",
+		},
+		{
+			name: "match host with negation",
+			config: `Match Host *.example.com !*.test.example.com
+    Port 2222`,
+			alias:   "dev.example.com",
+			key:     "Port",
+			wantVal: "2222",
+		},
+		{
+			name: "match host with negation - negated match",
+			config: `Match Host *.example.com !*.test.example.com
+    Port 2222`,
+			alias:   "dev.test.example.com",
+			key:     "Port",
+			wantVal: "",
+		},
+		{
+			name: "match host with comment",
+			config: `Match Host *.example.com  # Production servers
+    Port 2222`,
+			alias:   "test.example.com",
+			key:     "Port",
+			wantVal: "2222",
+		},
+		{
+			name: "match without host criterion",
+			config: `Match User admin
+    Port 2222`,
+			alias:    "test.example.com",
+			key:      "Port",
+			wantErr:  true,
+			errMatch: "Only Match Host is currently supported",
+		},
+		{
+			name: "match without criterion",
+			config: `Match
+    Port 2222`,
+			alias:    "test.example.com",
+			key:      "Port",
+			wantErr:  true,
+			errMatch: "Match directive requires at least one criterion",
+		},
+		{
+			name: "match host with equals",
+			config: `Match Host = *.example.com
+    Port 2222`,
+			alias:   "test.example.com",
+			key:     "Port",
+			wantVal: "2222",
+		},
+		{
+			name: "match host with multiple patterns",
+			config: `Match Host *.example.com *.example.org
+    Port 2222`,
+			alias:   "test.example.org",
+			key:     "Port",
+			wantVal: "2222",
+		},
+		{
+			name: "match host with identity file",
+			config: `Match Host *.prod.example.com
+    IdentityFile ~/.ssh/prod_key`,
+			alias:   "app.prod.example.com",
+			key:     "IdentityFile",
+			wantVal: "~/.ssh/prod_key",
+		},
+		{
+			name: "match host with multiple identity files",
+			config: `Match Host *.prod.example.com
+    IdentityFile ~/.ssh/prod_key1
+    IdentityFile ~/.ssh/prod_key2`,
+			alias:   "app.prod.example.com",
+			key:     "IdentityFile",
+			wantVal: "~/.ssh/prod_key1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Decode(strings.NewReader(tt.config))
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errMatch)
+				} else if !strings.Contains(err.Error(), tt.errMatch) {
+					t.Errorf("expected error containing %q, got %v", tt.errMatch, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got, err := cfg.Get(tt.alias, tt.key)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantVal {
+				t.Errorf("Get(%q, %q) = %q, want %q", tt.alias, tt.key, got, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestMatchHostFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		alias   string
+		key     string
+		wantVal string
+	}{
+		{
+			name:    "production server match",
+			alias:   "prod.example.com",
+			key:     "Port",
+			wantVal: "2222",
+		},
+		{
+			name:    "test server no match",
+			alias:   "dev.test.example.com",
+			key:     "Port",
+			wantVal: "22", // Falls through to Host *.example.com
+		},
+		{
+			name:    "ci server match",
+			alias:   "build.company.com",
+			key:     "Port",
+			wantVal: "3333",
+		},
+		{
+			name:    "deploy server match",
+			alias:   "deploy.company.com",
+			key:     "Port",
+			wantVal: "3333",
+		},
+		{
+			name:    "production server user",
+			alias:   "prod.example.com",
+			key:     "User",
+			wantVal: "admin",
+		},
+		{
+			name:    "test server user",
+			alias:   "dev.test.example.com",
+			key:     "User",
+			wantVal: "developer", // Falls through to Host *.example.com
+		},
+		{
+			name:    "production server identity file",
+			alias:   "prod.example.com",
+			key:     "IdentityFile",
+			wantVal: "~/.ssh/prod_key",
+		},
+		{
+			name:    "test server identity file",
+			alias:   "dev.test.example.com",
+			key:     "IdentityFile",
+			wantVal: "~/.ssh/dev_key", // Falls through to Host *.example.com
+		},
+	}
+
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/match-host"),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := us.Get(tt.alias, tt.key)
+			if got != tt.wantVal {
+				t.Errorf("Get(%q, %q) = %q, want %q", tt.alias, tt.key, got, tt.wantVal)
+			}
+		})
+	}
+
+	// Test GetAll for multiple IdentityFile values
+	t.Run("ci server multiple identity files", func(t *testing.T) {
+		got := us.GetAll("build.company.com", "IdentityFile")
+		want := []string{"~/.ssh/ci_key1", "~/.ssh/ci_key2"}
+		if len(got) != len(want) {
+			t.Errorf("GetAll(%q, %q) returned %d values, want %d", "build.company.com", "IdentityFile", len(got), len(want))
+		}
+		for i, w := range want {
+			if i >= len(got) {
+				t.Errorf("GetAll missing value at index %d, want %q", i, w)
+				continue
+			}
+			if got[i] != w {
+				t.Errorf("GetAll[%d] = %q, want %q", i, got[i], w)
+			}
+		}
+	})
+}
+
+func TestMatchDirectiveGetAll(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		alias    string
+		key      string
+		wantVals []string
+		wantErr  bool
+		errMatch string
+	}{
+		{
+			name: "match host with multiple identity files",
+			config: `Match Host *.prod.example.com
+    IdentityFile ~/.ssh/prod_key1
+    IdentityFile ~/.ssh/prod_key2`,
+			alias:    "app.prod.example.com",
+			key:      "IdentityFile",
+			wantVals: []string{"~/.ssh/prod_key1", "~/.ssh/prod_key2"},
+		},
+		{
+			name: "match host with single identity file",
+			config: `Match Host *.prod.example.com
+    IdentityFile ~/.ssh/prod_key`,
+			alias:    "app.prod.example.com",
+			key:      "IdentityFile",
+			wantVals: []string{"~/.ssh/prod_key"},
+		},
+		{
+			name: "match host with identity files and negation",
+			config: `Match Host *.example.com !*.test.example.com
+    IdentityFile ~/.ssh/prod_key1
+    IdentityFile ~/.ssh/prod_key2`,
+			alias:    "dev.test.example.com",
+			key:      "IdentityFile",
+			wantVals: []string{}, // Should not match due to negation
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Decode(strings.NewReader(tt.config))
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errMatch)
+				} else if !strings.Contains(err.Error(), tt.errMatch) {
+					t.Errorf("expected error containing %q, got %v", tt.errMatch, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got, err := cfg.GetAll(tt.alias, tt.key)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.wantVals) {
+				t.Errorf("GetAll(%q, %q) returned %d values, want %d", tt.alias, tt.key, len(got), len(tt.wantVals))
+			}
+			for i, want := range tt.wantVals {
+				if i >= len(got) {
+					t.Errorf("GetAll(%q, %q) missing value at index %d, want %q", tt.alias, tt.key, i, want)
+					continue
+				}
+				if got[i] != want {
+					t.Errorf("GetAll(%q, %q)[%d] = %q, want %q", tt.alias, tt.key, i, got[i], want)
+				}
+			}
+		})
 	}
 }

--- a/testdata/match-host
+++ b/testdata/match-host
@@ -1,0 +1,16 @@
+# Test file for Match Host directives
+Match Host *.example.com !*.test.example.com  # Production servers
+    Port 2222
+    User admin
+    IdentityFile ~/.ssh/prod_key
+
+Host *.example.com
+    Port 22
+    User developer
+    IdentityFile ~/.ssh/dev_key
+
+Match Host build.* deploy.*  # CI/CD servers
+    Port 3333
+    User cicd
+    IdentityFile ~/.ssh/ci_key1
+    IdentityFile ~/.ssh/ci_key2 


### PR DESCRIPTION
Initial draft of adding Match support with major help from Cursor / Claude.  I'm particularly interested in getting a security review as there was a comment about that. So this is now supported:

```
Match Host *.example.com
  Compression yes
  HostName test.example.com
  Port 2222
  User hi_there
```