### PR TITLE
config: simplify composite literal in newConfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ WRITE_MAILMAP := $(GOPATH)/bin/write_mailmap
 lint:
 	go vet ./...
 	go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+	go run github.com/kevinburke/differ@latest gofmt -s -w .
 
 test:
 	@# the timeout helps guard against infinite recursion

--- a/config.go
+++ b/config.go
@@ -768,6 +768,8 @@ func NewInclude(directives []string, hasEquals bool, pos Position, comment strin
 			path = directives[i]
 		} else if system {
 			path = filepath.Join("/etc/ssh", directives[i])
+		} else if strings.HasPrefix(directives[i], "~/") {
+			path = filepath.Join(homedir(), directives[i][2:])
 		} else {
 			path = filepath.Join(homedir(), ".ssh", directives[i])
 		}
@@ -865,7 +867,7 @@ func init() {
 func newConfig() *Config {
 	return &Config{
 		Hosts: []*Host{
-			&Host{
+			{
 				implicit: true,
 				Patterns: []*Pattern{matchAll},
 				Nodes:    make([]Node, 0),


### PR DESCRIPTION
Also add a check to the repo to ensure that we can't make this same mistake again. Uses github.com/kevinburke/differ to run gofmt -s -w and fail if any files are modified, catching redundant type annotations in composite literals and other simplifications.