### PR TITLE
config: support ~ as user's home directory in Include

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,11 +1,13 @@
 Carlos A Becker <caarlos0@gmail.com>
+Claude Opus 4.6 <noreply@anthropic.com>
 Dustin Spicuzza <dustin@virtualroadside.com>
 Eugene Terentev <eugene@terentev.net>
 Kevin Burke <kevin@burke.dev>
 Mark Nevill <nev@improbable.io>
+Neil Williams <neil@reddit.com>
 Scott Lessans <slessans@gmail.com>
 Sergey Lukjanov <me@slukjanov.name>
 Simon Josefsson <simon@josefsson.org>
-sio2boss <sio2boss@users.noreply.github.com>
 Wayne Ashley Berry <wayneashleyberry@gmail.com>
 santosh653 <70637961+santosh653@users.noreply.github.com>
+sio2boss <sio2boss@users.noreply.github.com>

--- a/config_test.go
+++ b/config_test.go
@@ -404,6 +404,32 @@ func TestIncludeString(t *testing.T) {
 	}
 }
 
+var shellIncludeFile = []byte(`
+# This host should not exist, so we can use it for test purposes / it won't
+# interfere with any other configurations.
+Host kevinburke.ssh_config.test.example.com
+    Port 4567
+`)
+
+func TestIncludeShellHomeDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fs write in short mode")
+	}
+	testPath := filepath.Join(homedir(), "kevinburke-ssh-config-shell-include")
+	err := os.WriteFile(testPath, shellIncludeFile, 0644)
+	if err != nil {
+		t.Skipf("couldn't write SSH config file: %v", err.Error())
+	}
+	defer os.Remove(testPath)
+	us := &UserSettings{
+		userConfigFinder: testConfigFinder("testdata/include-shell"),
+	}
+	val := us.Get("kevinburke.ssh_config.test.example.com", "Port")
+	if val != "4567" {
+		t.Errorf("expected to find Port=4567 in included file, got %q", val)
+	}
+}
+
 var matchTests = []struct {
 	in    []string
 	alias string

--- a/testdata/include-shell
+++ b/testdata/include-shell
@@ -1,0 +1,2 @@
+Host kevinburke.ssh_config.test.example.com
+    Include ~/kevinburke-ssh-config-shell-include


### PR DESCRIPTION
In ssh_config(5) it says:

    each pathname may contain glob(7) wildcards and, for user
    configurations, shell-like '~' references to user home directories.

This adds support for expanding the ~ into the path for the user's home directory when not parsing a system config.

Closes #31.