### PR TITLE
config: update default values to match current openssh-portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changes
 
+## Version 1.7 (unreleased)
+
+Update default values to match current openssh-portable (previously based on
+OpenSSH 7.4p1 from 2016).
+
+Breaking changes:
+
+- Remove `Cipher` default (SSH protocol 1 only, deprecated in openssh-portable)
+- Remove `ChallengeResponseAuthentication` default (alias for `KbdInteractiveAuthentication`)
+- Remove `CompressionLevel` default (unsupported in openssh-portable)
+- Remove `Protocol` default (silently ignored in openssh-portable)
+- Remove `RhostsRSAAuthentication` default (SSH protocol 1 only, unsupported)
+- Remove `RSAAuthentication` default (SSH protocol 1 only, unsupported)
+- Remove `UsePrivilegedPort` default (deprecated in openssh-portable)
+- Remove `IdentityFile` default of `~/.ssh/identity` (SSH protocol 1 only)
+- Change `CheckHostIP` default from `"yes"` to `"no"`
+- Change `UpdateHostKeys` default from `"no"` to `"yes"`
+- Change `Ciphers` default to remove CBC ciphers
+- Change `KexAlgorithms` default to add post-quantum algorithms and remove SHA1 variants
+- Change `HostKeyAlgorithms` default to add sk-*, webauthn-*, rsa-sha2-* and remove ssh-rsa
+- Change `HostbasedKeyTypes` default (same as `HostKeyAlgorithms`)
+- Change `PubkeyAcceptedKeyTypes` default (same as `HostKeyAlgorithms`)
+- Change `ForwardX11Timeout` default from `"20m"` to `"1200"` (same duration, now in seconds)
+- Rename `defaultProtocol2Identities` to `defaultIdentityFiles`
+- Remove `~/.ssh/id_dsa` from default identity files
+- Remove `ForwardAgent` from strict yes/no validation (now also accepts a socket path)
+- Remove `CompressionLevel` from uint validation
+
+Other changes:
+
+- Add `ControlPersist` default (`"no"`)
+- Add `RequestTTY` default (`"auto"`)
+- Add `SessionType` default (`"default"`)
+- Add `CASignatureAlgorithms` default
+- Add `HostbasedAcceptedAlgorithms` default (new name for `HostbasedKeyTypes`)
+- Add `PubkeyAcceptedAlgorithms` default (new name for `PubkeyAcceptedKeyTypes`)
+- Add `~/.ssh/id_ecdsa_sk` and `~/.ssh/id_ed25519_sk` to default identity files
+
 ## Version 1.6 (released February 16, 2026)
 
 - Support `~` as the user's home directory in `Include` directives, matching

--- a/config_test.go
+++ b/config_test.go
@@ -110,23 +110,26 @@ func TestGetIdentities(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected nil err, got %v", err)
 	}
-	if len(val) != len(defaultProtocol2Identities) {
+	if len(val) != len(defaultIdentityFiles) {
 		// TODO: return the right values here.
 		log.Printf("expected defaults, got %v", val)
 	} else {
-		for i, v := range defaultProtocol2Identities {
+		for i, v := range defaultIdentityFiles {
 			if val[i] != v {
 				t.Errorf("invalid %d in val, expected %s got %s", i, v, val[i])
 			}
 		}
 	}
 
+	// "protocol1" host sets Protocol 1, but Protocol is ignored in modern
+	// OpenSSH (only SSH2 exists). No IdentityFile is set for this host, so
+	// the result is empty (IdentityFile has no single default value).
 	val, err = us.GetAllStrict("protocol1", "IdentityFile")
 	if err != nil {
 		t.Errorf("expected nil err, got %v", err)
 	}
-	if len(val) != 1 || val[0] != "~/.ssh/identity" {
-		t.Errorf("expected [\"~/.ssh/identity\"], got %v", val)
+	if len(val) != 0 {
+		t.Errorf("expected [], got %v", val)
 	}
 }
 


### PR DESCRIPTION
The defaults were originally sourced from OpenSSH_7.4p1 (2016). Update them to match the current openssh-portable source (readconf.c, myproposal.h).

Removed keywords that are deprecated or unsupported in modern OpenSSH: Cipher (SSH1), ChallengeResponseAuthentication (alias for KbdInteractiveAuthentication), CompressionLevel, Protocol, RhostsRSAAuthentication, RSAAuthentication, UsePrivilegedPort, and the SSH1 IdentityFile default (~/.ssh/identity).

Updated defaults that have changed: CheckHostIP (yes→no), UpdateHostKeys (no→yes), Ciphers (removed CBC), KexAlgorithms (added post-quantum mlkem768x25519/sntrup761x25519, removed SHA1 variants), and all public key algorithm lists (added sk-*, webauthn-*, rsa-sha2-*; removed ssh-rsa).

Added new keywords: ControlPersist, RequestTTY, SessionType, CASignatureAlgorithms, HostbasedAcceptedAlgorithms, and PubkeyAcceptedAlgorithms.

Renamed defaultProtocol2Identities to defaultIdentityFiles, removed id_dsa, added id_ecdsa_sk and id_ed25519_sk. Removed ForwardAgent from strict yes/no validation (it now also accepts a socket path).