### PR TITLE
github: add daily Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,8 @@ updates:
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Set Dependabot to run daily for the existing Go module updates and\nadd a daily GitHub Actions update job so workflow dependencies stay\ncurrent as well.\n\nThis keeps the repository aligned with the automation requirement for\ndaily checks while covering both the primary Go code and the CI\nworkflow dependencies used in this repo.

